### PR TITLE
support non-blog post fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "lambda",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "googleapis": "^95.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "google-drive-blog",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This allows me to fetch (by name only) other markdown files for use on my website but not conflate them with the blog.

It seemed easier to do this than to create a parallel API. This has the drawback if I create a lot of non-blog content of making the pagination weird, but I don't expect that to happen.

Also upping version to `1.2.0` to account for previous revisions