### PR TITLE
fix logic to query smartly rather than grab everything and filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lambda",
-  "version": "1.2.0",
+  "name": "google-drive-blog-api",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "googleapis": "^95.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "google-drive-blog",
-    "version": "1.2.0",
+    "name": "google-drive-blog-api",
+    "version": "1.2.1",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Added enough content where the last 25 items wasn't enough to keep the blog page updated, but found [query examples](https://developers.google.com/drive/api/guides/search-files) for the drive api which allowed me to improve the logic, hopefully not needing to be modified again